### PR TITLE
Add links to base2tone-mate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository is like an umbrella over these dedicated repositories for genera
 - [iTerm2](https://github.com/atelierbram/Base2Tone-iterm2)
 - [Terminal – Mac Os X](https://github.com/atelierbram/Base2Tone-terminal)
 - [Markdown](https://github.com/atelierbram/Base2Tone-markdown)
+- [mate-terminal](https://github.com/llimllib/Base2Tone-mate)
 - [Prism](https://github.com/atelierbram/Base2Tone-prism)
 - [Sublime Text (and Textmate)](https://github.com/atelierbram/Base2Tone-sublime-text)
 - [Vim](https://github.com/atelierbram/Base2Tone-vim)

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <li><a href="https://github.com/atelierbram/Base2Tone-highlight.js">Highlight.js</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-hyperterm">HyperTerm</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-iterm2">iTerm2</a></li>
+      <li><a href="https://github.com/llimllib/Base2Tone-mate">mate-terminal</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-terminal">Terminal <small>(Mac OS X)</small></a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-markdown">Markdown (color-value tables)</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-prism">Prism</a></li>

--- a/src/inc/intro.inc
+++ b/src/inc/intro.inc
@@ -8,6 +8,7 @@
       <li><a href="https://github.com/atelierbram/Base2Tone-highlight.js">Highlight.js</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-hyperterm">HyperTerm</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-iterm2">iTerm2</a></li>
+      <li><a href="https://github.com/llimllib/Base2Tone-mate">mate-terminal</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-terminal">Terminal <small>(Mac OS X)</small></a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-markdown">Markdown (color-value tables)</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-prism">Prism</a></li>


### PR DESCRIPTION
I switched to linux, and I love base2tone, so I copied your iterm2 themes for mate-terminal. This PR just links to the repo containing the theme scripts for mate-terminal.

If you think linking my repo is OK, I'm not sure how you publish to gh-pages, do you edit directly? Should I file a PR against that branch as well?