### PR TITLE
Link gnome terminal color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 This repository is like an umbrella over these dedicated repositories for generating syntax-highlighting themes:
 
 - [CodeMirror](https://github.com/atelierbram/Base2Tone-codemirror)
+- [Gnome Terminal](https://github.com/llimllib/Base2Tone-gnome-terminal)
 - [Highlight.js](https://github.com/atelierbram/Base2Tone-highlight.js)
 - [HyperTerm](https://github.com/atelierbram/Base2Tone-hyperterm)
 - [iTerm2](https://github.com/atelierbram/Base2Tone-iterm2)

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <p>Dedicated repositories for generating syntax-highlighting themes:</p>
     <ul class="list-bullets fs-larger">
       <li><a href="https://github.com/atelierbram/Base2Tone-codemirror">CodeMirror</a></li>
+      <li><a href="https://github.com/llimllib/Base2Tone-gnome-terminal">Gnome Terminal</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-highlight.js">Highlight.js</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-hyperterm">HyperTerm</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-iterm2">iTerm2</a></li>

--- a/src/inc/intro.inc
+++ b/src/inc/intro.inc
@@ -5,6 +5,7 @@
   <p>Dedicated repositories for generating syntax-highlighting themes:</p>
     <ul class="list-bullets fs-larger">
       <li><a href="https://github.com/atelierbram/Base2Tone-codemirror">CodeMirror</a></li>
+      <li><a href="https://github.com/llimllib/Base2Tone-gnome-terminal">Gnome Terminal</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-highlight.js">Highlight.js</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-hyperterm">HyperTerm</a></li>
       <li><a href="https://github.com/atelierbram/Base2Tone-iterm2">iTerm2</a></li>


### PR DESCRIPTION
I'm still figuring out my linux setup, so now I ported base2tone to the gnome terminal. This PR just links to the gnome terminal theme repo.

(Thanks again for base2tone, I have spent so many hours using your color themes!)